### PR TITLE
handle error without errors object

### DIFF
--- a/source/AndroidPublisher/Exception/ErrorException.php
+++ b/source/AndroidPublisher/Exception/ErrorException.php
@@ -44,9 +44,11 @@ class ErrorException extends Exception implements InitializationInterface {
      */
     public static function initializeByString($string) {
         $Object = json_decode($string);
-        if (!is_null($Object)) {
+        if (!is_null($Object) && isset($Object->error)) {
             $ErrorException = new static($Object->error->message, $Object->error->code);
-            $ErrorException->errors = (array) $Object->error->errors;
+            if (isset($Object->error->errors)) {
+                $ErrorException->errors = (array) $Object->error->errors;
+            }
         } else {
             $ErrorException = new static($string);
         }

--- a/test/AndroidPublisher/Exception/ErrorExceptionTest.php
+++ b/test/AndroidPublisher/Exception/ErrorExceptionTest.php
@@ -207,4 +207,20 @@ final class ErrorExceptionTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('0', $Exception3->getCode());
         $this->assertEquals('Not Found', $Exception3->getMessage());
     }
+
+    public function testMissingErrorFields() {
+        $Exception1 = ErrorException::initializeByString('{
+ "error": {
+  "code": 404,
+  "message": "Not found"
+ }
+}');
+        $this->assertInstanceOf(ErrorException::class, $Exception1);
+        $this->assertEquals('404', $Exception1->getCode());
+        $this->assertEquals('Not found', $Exception1->getMessage());
+
+        $Exception2 = ErrorException::initializeByString('Not found');
+        $this->assertInstanceOf(ErrorException::class, $Exception2);
+        $this->assertEquals('Not found', $Exception2->getMessage());
+    }
 }


### PR DESCRIPTION
test result before changes
```
1) alxmsl\Test\Google\AndroidPublisher\ErrorExceptionTest::testMissingErrorFields
Undefined property: stdClass::$errors
```